### PR TITLE
ci: bump docker_publish Node to 24

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm install --include=dev


### PR DESCRIPTION
Astro 5.16+ requires Node >=22.12. Align docker_publish with deploy_github_pages and analyse_code_sonar which already use Node 24. Unblocks #63.